### PR TITLE
Fixed Heroku Port Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,7 @@ const MIDDLEWARE = require('./config/middleware')
 const ROUTES = require('./config/routes')
 const SERVER = EXPRESS()
 
-const { SERVER_PORT } = process.env
-const PORT = SERVER_PORT || 5000
+const PORT = process.env.PORT || 21310 
 
 MIDDLEWARE(SERVER)
 ROUTES(SERVER)


### PR DESCRIPTION
# Description

I fixed the Heroku port error that was preventing the back-end server from deploying successfully. The error was the result of defining my own port instead of configuring my server to listen for process.env.Port which is used by Heroku to dynamically assign a port to any web application.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I am unable to test the resolution of this error on the back-end site until this pull request is merged.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings